### PR TITLE
Fixes a typo in the colors file

### DIFF
--- a/colors.sh
+++ b/colors.sh
@@ -31,7 +31,7 @@ undwht='\e[4;37m' # White
 # Background
 bakblk='\e[40m'   # Black
 bakred='\e[41m'   # Red
-badgrn='\e[42m'   # Green
+bakgrn='\e[42m'   # Green
 bakylw='\e[43m'   # Yellow
 bakblu='\e[44m'   # Blue
 bakpur='\e[45m'   # Purple


### PR DESCRIPTION
The variable for green background was misspelled. This commit will fix it.
