### PR TITLE
Updated to use porcelain Git commands

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -18,7 +18,8 @@ find_git_dirty() {
 		git_dirty=''
 	else
 		# Based on: http://stackoverflow.com/a/2659808/170413
-		if git diff-files --quiet
+		local err
+		if err=$(git diff-files --quiet 2>&1)
 		then
 			if git diff-index --quiet --cached HEAD
 			then
@@ -27,6 +28,11 @@ find_git_dirty() {
 				# Can't figure out different colors
 				git_dirty="^"
 			fi
+		elif [ -n "$err" ]
+		then
+			# Some error - most likely that it was run within $GIT_DIR
+			# Resolve repo root instead? `git rev-parse --git-dir` does not work, nor does the 'git root' alias trick
+			git_dirty=""
 		else
 			git_dirty="*"
 		fi


### PR DESCRIPTION
Updated find_git_branch to use git rev-parse, and updated find_git_dirty to use git diff-files. I think this solves the issue with submodules, and makes it a little more robust (i.e., for feature / release branches from git-flow).

I also changed the function style to reflect what is used in some of git-core, and I removed the preceding space in the branch name (like another Git prompt tutorial had -- forgot the link) for personal preference.

Thank you for this awesome utility!
