### PR TITLE
Use tput to generate color codes

### DIFF
--- a/colors.sh
+++ b/colors.sh
@@ -1,40 +1,41 @@
 # Regular
-txtblk='\e[0;30m' # Black
-txtred='\e[0;31m' # Red
-txtgrn='\e[0;32m' # Green
-txtylw='\e[0;33m' # Yellow
-txtblu='\e[0;34m' # Blue
-txtpur='\e[0;35m' # Purple
-txtcyn='\e[0;36m' # Cyan
-txtwht='\e[0;37m' # White
+txtblk="$(tput setaf 0)"  # Black
+txtred="$(tput setaf 1)"  # Red
+txtgrn="$(tput setaf 2)"  # Green
+txtylw="$(tput setaf 3)"  # Yellow
+txtblu="$(tput setaf 4)"  # Blue
+txtpur="$(tput setaf 5)"  # Purple
+txtcyn="$(tput setaf 6)"  # Cyan
+txtwht="$(tput setaf 7)"  # White
 
 # Bold
-bldblk='\e[1;30m' # Black
-bldred='\e[1;31m' # Red
-bldgrn='\e[1;32m' # Green
-bldylw='\e[1;33m' # Yellow
-bldblu='\e[1;34m' # Blue
-bldpur='\e[1;35m' # Purple
-bldcyn='\e[1;36m' # Cyan
-bldwht='\e[1;37m' # White
+bldblk="$(tput setaf 0)$(tput bold)"  # Black
+bldred="$(tput setaf 1)$(tput bold)"  # Red
+bldgrn="$(tput setaf 2)$(tput bold)"  # Green
+bldylw="$(tput setaf 3)$(tput bold)"  # Yellow
+bldblu="$(tput setaf 4)$(tput bold)"  # Blue
+bldpur="$(tput setaf 5)$(tput bold)"  # Purple
+bldcyn="$(tput setaf 6)$(tput bold)"  # Cyan
+bldwht="$(tput setaf 7)$(tput bold)"  # White
 
 # Underline
-undblk='\e[4;30m' # Black
-undred='\e[4;31m' # Red
-undgrn='\e[4;32m' # Green
-undylw='\e[4;33m' # Yellow
-undblu='\e[4;34m' # Blue
-undpur='\e[4;35m' # Purple
-undcyn='\e[4;36m' # Cyan
-undwht='\e[4;37m' # White
+undblk="$(tput setaf 0)$(tput smul)"  # Black
+undred="$(tput setaf 1)$(tput smul)"  # Red
+undgrn="$(tput setaf 2)$(tput smul)"  # Green
+undylw="$(tput setaf 3)$(tput smul)"  # Yellow
+undblu="$(tput setaf 4)$(tput smul)"  # Blue
+undpur="$(tput setaf 5)$(tput smul)"  # Purple
+undcyn="$(tput setaf 6)$(tput smul)"  # Cyan
+undwht="$(tput setaf 7)$(tput smul)"  # White
 
 # Background
-bakblk='\e[40m'   # Black
-bakred='\e[41m'   # Red
-bakgrn='\e[42m'   # Green
-bakylw='\e[43m'   # Yellow
-bakblu='\e[44m'   # Blue
-bakpur='\e[45m'   # Purple
-bakcyn='\e[46m'   # Cyan
-bakwht='\e[47m'   # White
-txtrst='\e[0m'    # Text Reset
+bakblk="$(tput setab 0)"  # Black
+bakred="$(tput setab 1)"  # Red
+bakgrn="$(tput setab 2)"  # Green
+bakylw="$(tput setab 3)"  # Yellow
+bakblu="$(tput setab 4)"  # Blue
+bakpur="$(tput setab 5)"  # Purple
+bakcyn="$(tput setab 6)"  # Cyan
+bakwht="$(tput setab 7)"  # White
+
+txtrst="$(tput sgr 0)"    # Text Reset


### PR DESCRIPTION
This allows "echo", among other commands, to use these sequences under OS X (where echo doesn't support the `-e` flag).
