### PR TITLE
Enclose variable in double qoutes, so it is treated as string

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1,2 +1,2 @@
-source $GITAWAREPROMPT/colors.sh
-source $GITAWAREPROMPT/prompt.sh
+source "$GITAWAREPROMPT"/colors.sh
+source "$GITAWAREPROMPT"/prompt.sh


### PR DESCRIPTION
The script breakes when path contains special characters or spaces, i.e. spaces in username. I believe this will fix the problem.