### PR TITLE
Use printf instead of echo in colors.sh

### DIFF
--- a/colors.sh
+++ b/colors.sh
@@ -1,42 +1,42 @@
 # Regular
-txtblk="$(tput setaf 0 2>/dev/null || echo '\e[0;30m')"  # Black
-txtred="$(tput setaf 1 2>/dev/null || echo '\e[0;31m')"  # Red
-txtgrn="$(tput setaf 2 2>/dev/null || echo '\e[0;32m')"  # Green
-txtylw="$(tput setaf 3 2>/dev/null || echo '\e[0;33m')"  # Yellow
-txtblu="$(tput setaf 4 2>/dev/null || echo '\e[0;34m')"  # Blue
-txtpur="$(tput setaf 5 2>/dev/null || echo '\e[0;35m')"  # Purple
-txtcyn="$(tput setaf 6 2>/dev/null || echo '\e[0;36m')"  # Cyan
-txtwht="$(tput setaf 7 2>/dev/null || echo '\e[0;37m')"  # White
+txtblk="$(tput setaf 0 2>/dev/null || printf '\e[0;30m')"  # Black
+txtred="$(tput setaf 1 2>/dev/null || printf '\e[0;31m')"  # Red
+txtgrn="$(tput setaf 2 2>/dev/null || printf '\e[0;32m')"  # Green
+txtylw="$(tput setaf 3 2>/dev/null || printf '\e[0;33m')"  # Yellow
+txtblu="$(tput setaf 4 2>/dev/null || printf '\e[0;34m')"  # Blue
+txtpur="$(tput setaf 5 2>/dev/null || printf '\e[0;35m')"  # Purple
+txtcyn="$(tput setaf 6 2>/dev/null || printf '\e[0;36m')"  # Cyan
+txtwht="$(tput setaf 7 2>/dev/null || printf '\e[0;37m')"  # White
 
 # Bold
-bldblk="$(tput setaf 0 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;30m')"  # Black
-bldred="$(tput setaf 1 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;31m')"  # Red
-bldgrn="$(tput setaf 2 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;32m')"  # Green
-bldylw="$(tput setaf 3 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;33m')"  # Yellow
-bldblu="$(tput setaf 4 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;34m')"  # Blue
-bldpur="$(tput setaf 5 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;35m')"  # Purple
-bldcyn="$(tput setaf 6 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;36m')"  # Cyan
-bldwht="$(tput setaf 7 2>/dev/null)$(tput bold 2>/dev/null || echo '\e[1;37m')"  # White
+bldblk="$(tput setaf 0 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;30m')"  # Black
+bldred="$(tput setaf 1 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;31m')"  # Red
+bldgrn="$(tput setaf 2 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;32m')"  # Green
+bldylw="$(tput setaf 3 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;33m')"  # Yellow
+bldblu="$(tput setaf 4 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;34m')"  # Blue
+bldpur="$(tput setaf 5 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;35m')"  # Purple
+bldcyn="$(tput setaf 6 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;36m')"  # Cyan
+bldwht="$(tput setaf 7 2>/dev/null)$(tput bold 2>/dev/null || printf '\e[1;37m')"  # White
 
 # Underline
-undblk="$(tput setaf 0 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;30m')"  # Black
-undred="$(tput setaf 1 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;31m')"  # Red
-undgrn="$(tput setaf 2 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;32m')"  # Green
-undylw="$(tput setaf 3 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;33m')"  # Yellow
-undblu="$(tput setaf 4 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;34m')"  # Blue
-undpur="$(tput setaf 5 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;35m')"  # Purple
-undcyn="$(tput setaf 6 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;36m')"  # Cyan
-undwht="$(tput setaf 7 2>/dev/null)$(tput smul 2>/dev/null || echo '\e[4;37m')"  # White
+undblk="$(tput setaf 0 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;30m')"  # Black
+undred="$(tput setaf 1 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;31m')"  # Red
+undgrn="$(tput setaf 2 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;32m')"  # Green
+undylw="$(tput setaf 3 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;33m')"  # Yellow
+undblu="$(tput setaf 4 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;34m')"  # Blue
+undpur="$(tput setaf 5 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;35m')"  # Purple
+undcyn="$(tput setaf 6 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;36m')"  # Cyan
+undwht="$(tput setaf 7 2>/dev/null)$(tput smul 2>/dev/null || printf '\e[4;37m')"  # White
 
 # Background
-bakblk="$(tput setab 0 2>/dev/null || echo '\e[40m')"  # Black
-bakred="$(tput setab 1 2>/dev/null || echo '\e[41m')"  # Red
-bakgrn="$(tput setab 2 2>/dev/null || echo '\e[42m')"  # Green
-bakylw="$(tput setab 3 2>/dev/null || echo '\e[43m')"  # Yellow
-bakblu="$(tput setab 4 2>/dev/null || echo '\e[44m')"  # Blue
-bakpur="$(tput setab 5 2>/dev/null || echo '\e[45m')"  # Purple
-bakcyn="$(tput setab 6 2>/dev/null || echo '\e[46m')"  # Cyan
-bakwht="$(tput setab 7 2>/dev/null || echo '\e[47m')"  # White
+bakblk="$(tput setab 0 2>/dev/null || printf '\e[40m')"  # Black
+bakred="$(tput setab 1 2>/dev/null || printf '\e[41m')"  # Red
+bakgrn="$(tput setab 2 2>/dev/null || printf '\e[42m')"  # Green
+bakylw="$(tput setab 3 2>/dev/null || printf '\e[43m')"  # Yellow
+bakblu="$(tput setab 4 2>/dev/null || printf '\e[44m')"  # Blue
+bakpur="$(tput setab 5 2>/dev/null || printf '\e[45m')"  # Purple
+bakcyn="$(tput setab 6 2>/dev/null || printf '\e[46m')"  # Cyan
+bakwht="$(tput setab 7 2>/dev/null || printf '\e[47m')"  # White
 
 # Reset
-txtrst="$(tput sgr 0 2>/dev/null || echo '\e[0m')"  # Text Reset
+txtrst="$(tput sgr 0 2>/dev/null || printf '\e[0m')"  # Text Reset


### PR DESCRIPTION
`echo` (both the built-in command and /bin/echo) doesn't recognize the "\e" escape sequence on OS X. (This may not be an issue, since `$TERM` is typically only unset in non-interactive environments, so these could theoretically also be replaced with an empty `echo` or `printf`.)