### PR TITLE
Tag names

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -1,18 +1,20 @@
 find_git_branch() {
   # Based on: http://stackoverflow.com/a/13003854/170413
-  local branch
-  if branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null); then
-    if [[ "$branch" == "HEAD" ]]; then
-      branch=$(git name-rev --tags --name-only $(git rev-parse HEAD))
-    fi
-    if [[ $branch == *"~"* || $branch == *" "* ]]; then
-	git_branch="(detached*)";
+    local branch
+    if branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null); then
+	if [[ "$branch" == "HEAD" ]]; then
+	    branch=$(git name-rev --tags --name-only $(git rev-parse HEAD))
+	    if [[ $branch == *"~"* || $branch == *" "* ]]; then
+		git_branch="(detached*)";
+	    else
+		git_branch="[$branch]"
+	    fi
+	else
+	    git_branch="($branch)"
+	fi
     else
-	git_branch="[$branch]"
+	git_branch=""
     fi
-    else
-    git_branch=""
-  fi
 }
 
 find_git_dirty() {

--- a/prompt.sh
+++ b/prompt.sh
@@ -3,10 +3,14 @@ find_git_branch() {
   local branch
   if branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null); then
     if [[ "$branch" == "HEAD" ]]; then
-      branch='detached*'
+      branch=$(git name-rev --tags --name-only $(git rev-parse HEAD))
     fi
-    git_branch="($branch)"
-  else
+    if [[ $branch == *"~"* || $branch == *" "* ]]; then
+	git_branch="(detached*)";
+    else
+	git_branch="[$branch]"
+    fi
+    else
     git_branch=""
   fi
 }
@@ -20,7 +24,7 @@ find_git_dirty() {
   fi
 }
 
-PROMPT_COMMAND="find_git_branch; find_git_dirty; $PROMPT_COMMAND"
+export PROMPT_COMMAND="find_git_branch; $PROMPT_COMMAND"
 
 # Default Git enabled prompt with dirty state
 # export PS1="\u@\h \w \[$txtcyn\]\$git_branch\[$txtred\]\$git_dirty\[$txtrst\]\$ "


### PR DESCRIPTION
I added this code to get tag names in case you checkout a specific tag. Instead of just writing detached* as branch name. 

You might want to include it the your main repo. I did not tested it extensively, but I will be actively using this fix from now on and will maintain it if necessary.