### PR TITLE
Remove duplicate whitespace for Ubuntu PS1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ export SUDO_PS1="\[$bakred\]\u@\h\[$txtrst\] \w\$ "
 Standard:
 
 ```bash
-export PS1="\${debian_chroot:+(\$debian_chroot)}\u@\h:\w \[$txtcyn\]\$git_branch\[$txtred\]\$git_dirty\[$txtrst\]\$ "
+export PS1="\${debian_chroot:+(\$debian_chroot)}\u@\h:\w\[$txtcyn\]\$git_branch\[$txtred\]\$git_dirty\[$txtrst\]\$ "
 ```
 
 Colorized:


### PR DESCRIPTION
Adjust the prompt string from

```
user@host:~/project  (release-3.0)$
```

to

```
user@host:~/project (release-3.0)$
```

Note the removal of the duplicate whitespace.
