### PR TITLE
Auto Configure GITAWAREPROMPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ git clone git://github.com/jimeh/git-aware-prompt.git
 Edit your `~/.bash_profile` or `~/.profile` and add the following to the top:
 
 ```bash
-export GITAWAREPROMPT=~/.bash/git-aware-prompt
-source "${GITAWAREPROMPT}/main.sh"
+source ~/.bash/git-aware-prompt/main.sh
 ```
 
 

--- a/main.sh
+++ b/main.sh
@@ -1,2 +1,3 @@
+GITAWAREPROMPT=`dirname "${BASH_SOURCE[0]}"`
 source "${GITAWAREPROMPT}/colors.sh"
 source "${GITAWAREPROMPT}/prompt.sh"


### PR DESCRIPTION
With a small addition to `main.sh` the scrip dir can be detected automatically, so that the user does not need to define the `GITAWAREPROMPT` env var manually in their `.bash_profile`.