### PR TITLE
Performance improvement for large repos! (Avoid using "git status")

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -12,9 +12,21 @@ find_git_branch() {
 }
 
 find_git_dirty() {
-  local status=$(git status --porcelain 2> /dev/null)
-  if [[ "$status" != "" ]]; then
-    git_dirty='*'
+  local branch
+  if branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null); then
+    #local status=$(git status --porcelain 2> /dev/null)  # very slow for large repos!
+    #local has_staged_changes=$(git diff-index --quiet --cached HEAD 2> /dev/null)
+    #local has_stageable_files=$(git diff-files --quiet  2> /dev/null)
+    local status=$(git diff-index --quiet HEAD  2> /dev/null ; echo $?)
+    if [[ "$status" == "0" ]]; then
+      git_dirty=''
+    elif [[ "$status" == "1" ]]; then
+      git_dirty='*'
+    elif [[ "$status" == "128" ]]; then
+      git_dirty=' no_worktree'
+    else
+      git_dirty=" err_$status" # to show if anything else went wrong.
+    fi
   else
     git_dirty=''
   fi


### PR DESCRIPTION
The function find_git_dirty() delayed prompt display by over a second when in a large repo, so I now use the plumbing commands instead of "git status". Because we don't actually need to generate a list of all the changed files just to see if the repo is dirty. Further improvements possible.

Also, there's some more verbosity to keep the command output reliable. 
(Errcode 128 applies e.g. when in any .git folder)

Finally, I surrounded this by the test for branch name as in find_git_branch(), to avoid output on non-git folders. Other implementation imaginable.