### PR TITLE
Fixed Ubuntu bashrc setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd ~/.bash
 git clone git://github.com/jimeh/git-aware-prompt.git
 ```
 
-Edit your `~/.bash_profile` or `~/.profile` or `~/.bashrc` (for Ubuntu) and add the following to the top:
+Edit your `~/.bash_profile` or `~/.profile` or `~/.bashrc` (for Ubuntu) and add the following to the top (or bottom for Ubuntu):
 
 ```bash
 export GITAWAREPROMPT=~/.bash/git-aware-prompt


### PR DESCRIPTION
Installation did not work for Ubuntu 18.10 with default instructions. Adding required commands to the bottom of .bashrc fixed it. 