### PR TITLE
Add a variable for showing repo name

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -1,3 +1,12 @@
+find_git_repo() {
+  local repo
+  if repo=$(git rev-parse --show-toplevel 2> /dev/null); then
+    git_repo="($(basename "$repo"))"
+  else
+    git_repo=""
+  fi
+}
+
 find_git_branch() {
   # Based on: http://stackoverflow.com/a/13003854/170413
   local branch
@@ -20,13 +29,16 @@ find_git_dirty() {
   fi
 }
 
-PROMPT_COMMAND="find_git_branch; find_git_dirty; $PROMPT_COMMAND"
+PROMPT_COMMAND="find_git_repo; find_git_branch; find_git_dirty; $PROMPT_COMMAND"
 
 # Default Git enabled prompt with dirty state
 # export PS1="\u@\h \w \[$txtcyn\]\$git_branch\[$txtred\]\$git_dirty\[$txtrst\]\$ "
 
 # Another variant:
 # export PS1="\[$bldgrn\]\u@\h\[$txtrst\] \w \[$bldylw\]\$git_branch\[$txtcyn\]\$git_dirty\[$txtrst\]\$ "
+
+# Another variant showing repository name
+# export PS1="\u@\h ]w \[$txtylw\]\$git_repo\[$txtcyn\]\$git_branch\[$txtred\]\$git_dirty\[$txtrst\]\$ "
 
 # Default Git enabled root prompt (for use with "sudo -s")
 # export SUDO_PS1="\[$bakred\]\u@\h\[$txtrst\] \w\$ "


### PR DESCRIPTION
I find that when working with multiple repositories – or especially with git submodules – it can be useful to see in the prompt which one I'm currently in. (This will often be the current working directory, but not always.)